### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.7.0 to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,20 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.7.1
+
+Released on 2026-03-16.
+
+### Bug fixes
+
+- fix: add missing docs to skip ([#85](https://github.com/usnistgov/cookiecutter-nist-python/pull/85))
+
+### Documentation
+
+- docs: dummy update ([#64](https://github.com/usnistgov/cookiecutter-nist-python/pull/64))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## Initial release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.7.0"
+version = "0.7.1"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -318,7 +318,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.