### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.7.2 to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.7.3
+
+Released on 2026-03-16.
+
+### Bug fixes
+
+- fix: bug fix in ci ([#101](https://github.com/usnistgov/cookiecutter-nist-python/pull/101))
+- fix: skip ci in update-package-version.yml ([#100](https://github.com/usnistgov/cookiecutter-nist-python/pull/100))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.7.2
 
 Released on 2026-03-16.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.7.2"
+version = "0.7.3"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -318,7 +318,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.7.2"
+version = "0.7.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)