### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.7.5 to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.8.0
+
+Released on 2026-03-17.
+
+### Enhancements
+
+- feat: update defaults ([#108](https://github.com/usnistgov/cookiecutter-nist-python/pull/108))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.7.5
 
 Released on 2026-03-17.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.7.5"
+version = "0.8.0"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-10T15:28:12.695688Z"
+exclude-newer = "2026-03-10T15:36:12.919387749Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -322,7 +322,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.7.5"
+version = "0.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)