### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.9.0 to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.10.0
+
+Released on 2026-03-27.
+
+### Enhancements
+
+- feat: use native markdown ruff formatting ([#136](https://github.com/usnistgov/cookiecutter-nist-python/pull/136))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.9.0
 
 Released on 2026-03-24.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.9.0"
+version = "0.10.0"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-20T18:43:42.006212Z"
+exclude-newer = "2026-03-20T20:19:35.10507826Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.9.0"
+version = "0.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)