### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.12.0 to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.13.0
+
+Released on 2026-06-02.
+
+### Enhancements
+
+- feat: better typer support ([#236](https://github.com/usnistgov/cookiecutter-nist-python/pull/236))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.12.0
 
 Released on 2026-03-31.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.12.0"
+version = "0.13.0"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.12.0"
+version = "0.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)