### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.14.1 to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.14.2
+
+Released on 2026-08-10.
+
+### Bug fixes
+
+- fix: pyproject fixes ([#325](https://github.com/usnistgov/cookiecutter-nist-python/pull/325))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.14.1
 
 Released on 2026-08-07.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.14.1"
+version = "0.14.2"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.14.1"
+version = "0.14.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)