### PR TITLE
chore(bump): bump cookiecutter-nist-python from 0.14.2 to 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `cookiecutter-nist-python`
 
+## 0.14.3
+
+Released on 2026-08-28.
+
+### Bug fixes
+
+- fix: pin prek>=0.5.0  ([#342](https://github.com/usnistgov/cookiecutter-nist-python/pull/342))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.14.2
 
 Released on 2026-08-10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiecutter-nist-python"
-version = "0.14.2"
+version = "0.14.3"
 description = "Cookiecutter template for NIST python packages"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-nist-python"
-version = "0.14.2"
+version = "0.14.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)